### PR TITLE
write shape-files into separate tmp-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ moveStack in Movebank format
 moveStack in Movebank format
 
 ### Artefacts
-`moveapps_shapefile/`: folder containing the shapefile files for input to a GIS software. The four files are `data.dbf`, `data.prj`, `data.shp` and `data.shx`, and contain all tracking data of the input data set.
-
-`data_shps.zip`: zipped file of the above named shapefile files to be loaded into GIS software.
+`data_shps.zip`: zipped file containing the shapefile files for input to a GIS software. The four files are `data.dbf`, `data.prj`, `data.shp` and `data.shx`, and contain all tracking data of the input data set.
 
 ### Parameters 
 no parameters

--- a/RFunction.R
+++ b/RFunction.R
@@ -7,10 +7,11 @@ rFunction <- function(data)
   
   data.spdf <- SpatialPointsDataFrame(coordinates(data),as.data.frame(data), proj4string=CRS("+proj=longlat +ellps=WGS84 +no_defs"))
   
-  targetDirZipFile <- Sys.getenv(x = "APP_ARTIFACTS_DIR", "/tmp")
+  dir.create(targetDirZipFile <- Sys.getenv(x = "APP_ARTIFACTS_DIR", "artefact-mock"))
   
-  targetDirShapeFiles <- paste0(targetDirZipFile,"/moveapps-shapefile")
-  dir.create(targetDirShapeFiles)
+  dir.create(targetDirShapeFiles <- tempdir())
+  targetDirShapeFiles <- paste0(targetDirShapeFiles,"/moveapps-shapefile")
+  logger.info(paste0("Storing shapefiles in tmp-dir ", targetDirShapeFiles))
   
   # careful, for writeOGR the column names have to be unique in the first 10 characters, that can be problematic and has to be adressed here
   for(i in seq(along=names(data.spdf@data)))
@@ -29,7 +30,7 @@ rFunction <- function(data)
   zip::zip(
     zipfile=paste0(targetDirZipFile,"/data_shps.zip"),
     files=  targetDirShapeFiles,
-    root = targetDirZipFile,
+    #root = targetDirZipFile,
     mode = "cherry-pick"
   )
 


### PR DESCRIPTION
We can not write intermediate files into the special artifacts location (`APP_ARTIFACTS_DIR`). Use a temporary directory.